### PR TITLE
Dbryan/remove h flags

### DIFF
--- a/datasets/process_mols.py
+++ b/datasets/process_mols.py
@@ -477,12 +477,14 @@ def get_fullrec_graph(rec, rec_coords, c_alpha_coords, n_coords, c_coords, compl
 
     return
 
-def write_mol_with_coords(mol, new_coords, path):
+def write_mol_with_coords(mol, new_coords, path, add_hs=False):
     w = Chem.SDWriter(path)
     conf = mol.GetConformer()
     for i in range(mol.GetNumAtoms()):
         x,y,z = new_coords.astype(np.double)[i]
         conf.SetAtomPosition(i,Point3D(x,y,z))
+    if add_hs:
+        mol = Chem.AddHs(mol, addCoords=True)
     w.write(mol)
     w.close()
 

--- a/inference.py
+++ b/inference.py
@@ -77,10 +77,11 @@ for name in complex_name_list:
 
 # CONIFER POINT
 # Defaults
+print(args)
 remove_hs_score = score_model_args.remove_hs
 remove_hs_confidence = confidence_args.remove_hs
 remove_hs_output = score_model_args.remove_hs
-keep_src_3d = True
+keep_src_3d = False
 
 # General override
 if args.keep_hs:
@@ -89,7 +90,7 @@ if args.keep_hs:
     remove_hs_output = False
 
 # Individual override
-truish = lambda x: x in ["true", "True", "1"]
+truish = lambda x: x in [True, "true", "True", "1"]
 if args.remove_hs_score is not None: remove_hs_score = truish(args.remove_hs_score)
 if args.remove_hs_confidence is not None: remove_hs_confidence = truish(args.remove_hs_confidence)
 if args.remove_hs_output is not None: remove_hs_output = truish(args.remove_hs_output)


### PR DESCRIPTION
Adds parameters `--keep_hs true` for preserving Hs and `--keep_src_3d true` for preserving the original conformation if from a molfile.

Also adds fine-grained params: --remove_hs_score, --remove_hs_confidence, and --remove_hs_output, but in reality these all have to be the same, otherwise there are errors.